### PR TITLE
Ingestion & MinIO Unit Testing, CICD

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,29 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          export PYTHONPATH=$PYTHONPATH:$(pwd)/src
+          pytest

--- a/dags/snowflake_load_dag.py
+++ b/dags/snowflake_load_dag.py
@@ -2,6 +2,11 @@ from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTr
 from airflow.sdk import dag, task, Asset, AssetWatcher
 import json
 import urllib.parse
+import sys 
+
+sys.path.append('/opt/airflow')
+from src.utils.minio import extract_json_as_jsonl_from_minio
+from src.utils.snowflake import get_snowflake_connection, copy_photos_to_snowflake
 
 def apply_function(*args, **kwargs):
     message = args[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 apache-airflow-providers-apache-kafka>=1.9.0
 apache-airflow-providers-common-messaging>=1.0.3
+pytest-mock>=3.10.0
+pytest-cov>=4.0.0
+requests-mock>=1.10.0
 snowflake-connector-python[pandas]
 snowflake-sqlalchemy
 pytest

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -14,11 +14,12 @@ def extract_photos_from_nasa(rover: str, sol: int, logger):
         response = requests.get(photos_request, timeout=30)
         response.raise_for_status()
         photos_response = response.json()
-    except requests.RequestException as e:
-        print(f"Error processing photos request for rover: {rover} on sol: {sol}: {e}")
-        logger.error(f"Error processing photos request for rover: {rover} on sol: {sol}: {e}")
-
-    return photos_response
+        return photos_response
+    except Exception as e:
+        error_msg = f"Error processing photos request for rover: {rover} on sol: {sol}: {e}"
+        print(error_msg)
+        logger.error(error_msg)
+        return {"photos": []}
 
 def extract_manifest_from_nasa(rover: str, logger):
     logger.info(f"Processing manifest request for rover: {rover}")
@@ -32,8 +33,9 @@ def extract_manifest_from_nasa(rover: str, logger):
         response = requests.get(manifest_request, timeout=30)
         response.raise_for_status()
         manifest_response = response.json()
-    except requests.RequestException as e:
-        print(f"Error processing manifest request for rover {rover}: {e}")
-        logger.error(f"Error processing manifest request for rover {rover}: {e}")
-
-    return manifest_response 
+        return manifest_response
+    except Exception as e:
+        error_msg = f"Error processing manifest request for rover {rover}: {e}"
+        print(error_msg)
+        logger.error(error_msg)
+        return {"manifest": []}

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch, MagicMock
+from src.ingestion import extract_photos_from_nasa
+
+def test_extract_photos_from_nasa():
+    """Test the NASA API extraction function"""
+    logger = MagicMock()
+    
+    with patch('requests.get') as mock_get:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "photos": [
+                {"id": 1, "img_src": "http://example.com/photo1.jpg"},
+                {"id": 2, "img_src": "http://example.com/photo2.jpg"}
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        result = extract_photos_from_nasa("Perseverance", 1, logger)
+        
+        assert result == {
+            "photos": [
+                {"id": 1, "img_src": "http://example.com/photo1.jpg"},
+                {"id": 2, "img_src": "http://example.com/photo2.jpg"}
+            ]
+        }
+        
+        mock_get.assert_called_once()
+        assert "rovers/Perseverance/photos" in mock_get.call_args[0][0]
+        assert "sol=1" in mock_get.call_args[0][0]
+
+def test_extract_photos_from_nasa_error():
+    """Test error handling in NASA API extraction"""
+    logger = MagicMock()
+    
+    with patch('requests.get') as mock_get:
+        mock_get.side_effect = Exception("API Error")
+        
+        result = extract_photos_from_nasa("Perseverance", 1, logger)
+        assert result == {"photos": []}
+        logger.error.assert_called()

--- a/tests/test_minio.py
+++ b/tests/test_minio.py
@@ -1,0 +1,146 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import json
+from datetime import datetime, timedelta
+
+from src.utils.minio import (
+    get_minio_client,
+    upload_json_to_minio,
+    extract_json_as_jsonl_from_minio,
+    get_recent_minio_files
+)
+
+@pytest.fixture
+def mock_minio_client():
+    with patch('minio.Minio') as mock_minio:
+        client = MagicMock()
+        mock_minio.return_value = client
+        yield client
+
+@pytest.fixture
+def sample_json_data():
+    return {
+        "photos": [
+            {"id": 1, "img_src": "http://example.com/photo1.jpg"},
+            {"id": 2, "img_src": "http://example.com/photo2.jpg"}
+        ]
+    }
+
+def test_get_minio_client(monkeypatch):
+    """Test Minio client initialization with environment variables"""
+    # Mock environment variables
+    env_vars = {
+        'MINIO_EXTERNAL_URL': 'localhost:9000',
+        'MINIO_ROOT_USER': 'testuser',
+        'MINIO_ROOT_PASSWORD': 'testpass'
+    }
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+    
+    # Mock load_dotenv to do nothing
+    with patch('src.utils.minio.load_dotenv'):
+        with patch('src.utils.minio.Minio') as mock_minio:
+            get_minio_client()
+            mock_minio.assert_called_once_with(
+                'localhost:9000',
+                access_key='testuser',
+                secret_key='testpass',
+                secure=False
+            )
+
+def test_upload_json_to_minio(mock_minio_client, sample_json_data, monkeypatch):
+    """Test uploading JSON data to MinIO"""
+    # Mock environment variable
+    monkeypatch.setenv('MINIO_BUCKET', 'test-bucket')
+    
+    # Set up mock client behavior
+    mock_minio_client.bucket_exists.return_value = False
+    
+    # Test uploading data
+    upload_json_to_minio(mock_minio_client, 'test/path.json', sample_json_data)
+    
+    # Verify bucket was created if it didn't exist
+    mock_minio_client.make_bucket.assert_called_once_with('test-bucket')
+    
+    # Verify put_object was called with correct parameters
+    mock_minio_client.put_object.assert_called_once()
+    call_args = mock_minio_client.put_object.call_args[1]
+    assert call_args['bucket_name'] == 'test-bucket'
+    assert call_args['object_name'] == 'test/path.json'
+    assert call_args['content_type'] == 'application/json'
+
+def test_extract_json_as_jsonl_from_minio(mock_minio_client, sample_json_data, monkeypatch, tmp_path):
+    """Test extracting JSON from MinIO and converting to JSONL"""
+    monkeypatch.setenv('MINIO_BUCKET_NAME', 'test-bucket')
+    test_file = tmp_path / "test.json"
+    
+    # Write sample data to temp file
+    with open(test_file, 'w') as f:
+        json.dump(sample_json_data, f)
+    
+    def mock_fget_object(bucket, src, dst):
+        with open(test_file, 'rb') as src_file:
+            with open(dst, 'wb') as dst_file:
+                dst_file.write(src_file.read())
+    
+    mock_minio_client.fget_object.side_effect = mock_fget_object
+    
+    # Test the function
+    result_path = extract_json_as_jsonl_from_minio(mock_minio_client, 'test/path.json')
+    
+    # Verify the JSONL file was created correctly
+    with open(result_path, 'r') as f:
+        jsonl_content = f.read().strip()
+        loaded_data = json.loads(jsonl_content)
+        assert loaded_data == sample_json_data
+
+@patch('src.utils.minio.setup_logger')
+def test_get_recent_minio_files(mock_logger, mock_minio_client, monkeypatch):
+    """Test retrieving recent files from MinIO"""
+    # Mock environment variable
+    monkeypatch.setenv('MINIO_BUCKET_NAME', 'test-bucket')
+    
+    # Set up logger mock
+    logger_instance = MagicMock()
+    mock_logger.return_value = logger_instance
+    
+    # Create mock objects with different timestamps
+    now = datetime.now()
+    recent_file = MagicMock()
+    recent_file.last_modified = now - timedelta(minutes=30)
+    recent_file.object_name = 'photos/recent.json'
+    
+    old_file = MagicMock()
+    old_file.last_modified = now - timedelta(minutes=120)
+    old_file.object_name = 'photos/old.json'
+    
+    # Mock list_objects to return our test files
+    mock_minio_client.list_objects.return_value = [recent_file, old_file]
+    
+    # Test the function
+    recent_files = get_recent_minio_files(mock_minio_client, minutes_ago=60)
+    
+    # Verify only recent files are returned
+    assert len(recent_files) == 1
+    assert recent_files[0] == 'photos/recent.json'
+
+@patch('src.utils.minio.setup_logger')
+def test_get_recent_minio_files_error_handling(mock_logger, mock_minio_client, monkeypatch):
+    """Test error handling in get_recent_minio_files"""
+    # Mock environment variable
+    monkeypatch.setenv('MINIO_BUCKET_NAME', 'test-bucket')
+    
+    # Set up logger mock
+    logger_instance = MagicMock()
+    mock_logger.return_value = logger_instance
+    
+    # Mock list_objects to raise an exception
+    mock_minio_client.list_objects.side_effect = Exception("Connection error")
+    
+    # Test the function
+    recent_files = get_recent_minio_files(mock_minio_client)
+    
+    # Verify empty list is returned on error
+    assert recent_files == []
+    # Verify error was logged
+    logger_instance.error.assert_called_once()


### PR DESCRIPTION
This pull request introduces automated Python testing in the CI workflow, improves error handling in NASA data extraction functions, and adds comprehensive unit tests for both NASA API and MinIO utility functions. The changes enhance reliability, test coverage, and integration with external services.

**CI/CD Integration**

* Added a new GitHub Actions workflow `.github/workflows/python-tests.yml` to automatically run Python tests on push and pull request events for the `main` and `dev` branches. This workflow sets up Python, installs dependencies, and runs tests using pytest.

**Testing Improvements**

* Added unit tests for NASA API extraction in `tests/test_ingestion.py`, covering both successful and error scenarios for `extract_photos_from_nasa`.
* Added comprehensive tests for MinIO utility functions in `tests/test_minio.py`, including client initialization, JSON upload, JSONL extraction, recent file retrieval, and error handling.

**Error Handling Enhancements**

* Updated `extract_photos_from_nasa` and `extract_manifest_from_nasa` in `src/ingestion.py` to handle all exceptions, log errors, and return empty results on failure, improving robustness against unexpected errors.

**DAG Integration**

* Modified `dags/snowflake_load_dag.py` to import MinIO and Snowflake utility functions, enabling their use in the DAG for data extraction and loading.