### PR TITLE
Fixed Discord Notifications

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -9,24 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Get PR details
-        id: pr
-        run: |
-          # Extract PR number from merge commit message
-          PR_NUMBER=$(echo "${{ github.event.head_commit.message }}" | grep -o '#[0-9]\+' | head -1 | sed 's/#//')
-          if [ ! -z "$PR_NUMBER" ]; then
-            # Get PR details using GitHub API
-            PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER")
-            PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // empty')
-            PR_BODY=$(echo "$PR_DATA" | jq -r '.body // empty')
-            echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
-            echo "pr_body<<EOF" >> $GITHUB_OUTPUT
-            echo "$PR_BODY" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          fi
-
       - name: Martian Moments Update
         uses: discord-actions/message@v2
         with:


### PR DESCRIPTION
Workflow simplification:

* Removed the "Get PR details" step, which previously extracted PR number from the commit message and fetched PR title and body using the GitHub API. (`.github/workflows/discord-notifications.yml`)