### PR TITLE
Quick Fix to 'Flat' Tables

### DIFF
--- a/dbt/martian_moments/models/staging/flat_coordinate_response.sql
+++ b/dbt/martian_moments/models/staging/flat_coordinate_response.sql
@@ -13,5 +13,6 @@ SELECT
     coordinate.value:properties.SCLK_START::int as sclk_start,
     coordinate.value:properties.SCLK_END::int as sclk_end  
 FROM 
-    {{ source('MARS_BRONZE', 'RAW_COORDINATE_RESPONSE') }},
+    {{ source('MARS_BRONZE', 'RAW_COORDINATE_RESPONSE') }} rcr,
     LATERAL FLATTEN(input => parse_json(coordinates)) as coordinate
+    WHERE rcr.ingestion_date = (SELECT MAX(ingestion_date) FROM {{ source('MARS_BRONZE', 'RAW_COORDINATE_RESPONSE') }})

--- a/dbt/martian_moments/models/staging/flat_manifest_response.sql
+++ b/dbt/martian_moments/models/staging/flat_manifest_response.sql
@@ -15,3 +15,4 @@ SELECT
 FROM 
     {{ source('MARS_BRONZE', 'RAW_MANIFEST_RESPONSE') }} rpr,
 LATERAL FLATTEN(input => parse_json(rpr.manifests)) as manifest
+WHERE rpr.ingestion_date = (SELECT MAX(ingestion_date) FROM {{ source('MARS_BRONZE', 'RAW_MANIFEST_RESPONSE') }})


### PR DESCRIPTION
This pull request updates the staging models to ensure that only the latest ingested data is processed from the source tables. The changes add a filter to select records with the most recent `ingestion_date` in both the coordinate and manifest response models.

Data freshness improvements:

* In `dbt/martian_moments/models/staging/flat_coordinate_response.sql`, added a `WHERE` clause to filter `RAW_COORDINATE_RESPONSE` records to only those with the latest `ingestion_date`.
* In `dbt/martian_moments/models/staging/flat_manifest_response.sql`, added a `WHERE` clause to filter `RAW_MANIFEST_RESPONSE` records to only those with the latest `ingestion_date`.